### PR TITLE
feat: allow running rdev in a thread

### DIFF
--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -59,7 +59,7 @@ where
             return Err(ListenError::LoopSourceError);
         }
 
-        let current_loop = CFRunLoopGetMain();
+        let current_loop = CFRunLoopGetCurrent();
         CFRunLoopAddSource(current_loop, _loop, kCFRunLoopCommonModes);
 
         CGEventTapEnable(tap, true);


### PR DESCRIPTION
### What does this PR do?
- This PR allows us to capture events on a non-main thread. At the moment, the `rdev` crate only works if run on the main thread.

### Why do we need this change?
- At the moment, the `listen` loop runs using `CFRunLoopGetMain` which returns the loop of the main thread. This causes problems if `rdev` listen is called in a non-main thread.
- We replace `CFRunLoopGetMain` with `CFRunLoopGetCurrent` which returns the loop of the current thread. This seems to fix the issue. This is also the way its done in the original `rdev` crate [LINK](https://github.com/Narsil/rdev/blob/5b8d4127e6c9c08553d0188bf812343ae06b19a1/src/macos/listen.rs#L58)


### Gotcha's
- The PR and other explanations are based on the understanding of the difference between `CFRunLoopGetCurrent` vs `CFRunLoopGetMain` which fixes the issue.