### PR TITLE
clean up the callback on `exit_grab()` for macos

### DIFF
--- a/src/macos/grab.rs
+++ b/src/macos/grab.rs
@@ -81,6 +81,7 @@ pub fn exit_grab() -> Result<(), GrabError> {
             CFRunLoopStop(CUR_LOOP);
             CUR_LOOP = std::ptr::null_mut();
         }
+        GLOBAL_CALLBACK = None;
     }
     Ok(())
 }


### PR DESCRIPTION
Otherwise the variables moved into it will never be dropped, and for example, channels inside the callback will not receive.