### PR TITLE
fix: macos, dead key

### DIFF
--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -208,6 +208,9 @@ pub unsafe fn convert(
             EventType::KeyPress(..) => {
                 let code =
                     cg_event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u32;
+                if code == kVK_Shift as _ || code == kVK_RightShift as _ {
+                    return None;
+                }
                 let flags = cg_event.get_flags();
                 let s = keyboard_state.create_unicode_for_key(code, flags);
                 // if s.is_none() {

--- a/src/macos/keyboard.rs
+++ b/src/macos/keyboard.rs
@@ -193,7 +193,6 @@ impl Keyboard {
         let mut buff = [0_u16; BUF_LEN];
         let kb_type = super::common::LMGetKbdType();
         let mut length = 0;
-        let last_dead_state = self.dead_state;
         let _retval = UCKeyTranslate(
             layout_ptr,
             code.try_into().ok()?,
@@ -209,24 +208,16 @@ impl Keyboard {
         if !keyboard.is_null() {
             CFRelease(keyboard);
         }
-        let mut cur_is_dead = self.is_dead();
-        if last_dead_state == 0 {
-            if self.dead_state != 0 {
-                return Some(UnicodeInfo {
+        if length == 0 {
+            return if self.is_dead() {
+                Some(UnicodeInfo {
                     name: None,
                     unicode: Vec::new(),
-                    is_dead: cur_is_dead,
-                });
-            }
-        } else {
-            if self.dead_state != 0 {
-                cur_is_dead = false;
-            }
-        }
-        // println!("{:?}", now.elapsed());
-
-        if length == 0 {
-            return None;
+                    is_dead: true,
+                })
+            } else {
+                None
+            };
         }
 
         // C0 controls
@@ -247,7 +238,7 @@ impl Keyboard {
         Some(UnicodeInfo {
             name: String::from_utf16(&unicode).ok(),
             unicode,
-            is_dead: cur_is_dead,
+            is_dead: false,
         })
     }
 


### PR DESCRIPTION
macOS -> RustDesk, "Translate mode", dead keys.

## Tests

- [x] fr -> en. `ê ë Ê Ë è È`
- [x] de -> en. `é è É É`