### PR TITLE
fix: macos, convert unicode, shift

### DIFF
--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -208,7 +208,12 @@ pub unsafe fn convert(
             EventType::KeyPress(..) => {
                 let code =
                     cg_event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u32;
-                if code == kVK_Shift as _ || code == kVK_RightShift as _ {
+                #[allow(non_upper_case_globals)]
+                let skip_unicode = match code as CGKeyCode {
+                    kVK_Shift | kVK_RightShift | kVK_ForwardDelete => true,
+                    _ => false,
+                };
+                if skip_unicode {
                     None
                 } else {
                     let flags = cg_event.get_flags();

--- a/src/macos/common.rs
+++ b/src/macos/common.rs
@@ -209,14 +209,15 @@ pub unsafe fn convert(
                 let code =
                     cg_event.get_integer_value_field(EventField::KEYBOARD_EVENT_KEYCODE) as u32;
                 if code == kVK_Shift as _ || code == kVK_RightShift as _ {
-                    return None;
+                    None
+                } else {
+                    let flags = cg_event.get_flags();
+                    let s = keyboard_state.create_unicode_for_key(code, flags);
+                    // if s.is_none() {
+                    //     s = Some(key_to_name(_k).to_owned())
+                    // }
+                    s
                 }
-                let flags = cg_event.get_flags();
-                let s = keyboard_state.create_unicode_for_key(code, flags);
-                // if s.is_none() {
-                //     s = Some(key_to_name(_k).to_owned())
-                // }
-                s
             }
             EventType::KeyRelease(..) => None,
             _ => None,


### PR DESCRIPTION
1. Fix `Shift` handle in dead key conversion, introduced in https://github.com/rustdesk-org/rdev/pull/10
Only `unicode` field should be `None`, not whole event.
2. macOS, convert unicode event, skip forward delete.