### PR TITLE
feat: make frequently-used types derive more traits

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -288,7 +288,7 @@ impl Default for RawKey {
 /// Standard mouse buttons
 /// Some mice have more than 3 buttons. These are not defined, and different
 /// OSs will give different `Button::Unknown` values.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Button {
     Left,
@@ -328,6 +328,7 @@ pub enum EventType {
 
 /// The Unicode information of input.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnicodeInfo {
     pub name: Option<String>,
     pub unicode: Vec<u16>,


### PR DESCRIPTION
There's an `Option<UnicodeInfo>` field in `Event` struct. `Event` will derive `Serialize` and `Deserialize` when `serialize` feature is enabled, but `UnicodeInfo` doesn't derive these 2 traits.

Besides, also make `Button` derive `Hash` and `EnumIter`.