### PR TITLE
fix: UnicodeInfo is now Serializable with serialize feature set

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -328,6 +328,7 @@ pub enum EventType {
 
 /// The Unicode information of input.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnicodeInfo {
     pub name: Option<String>,
     pub unicode: Vec<u16>,


### PR DESCRIPTION
Added serialization support for the UnicodeInfo struct when using the `serialize` feature. Previously, while the overall Event data structure was set up for serialization with serde, the added UnicodeInfo struct was missing the feature flag guard and derive statements. This patch fixes that, ensuring the entire event structure can be properly serialized again when the `serialize` feature is enabled.