### PR TITLE
feat: add exit_listen func to stop listening

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,9 @@ pub use crate::codes_conv::*;
 pub use keycodes::android::{
     code_from_key as android_keycode_from_key, key_from_code as android_key_from_code,
 };
+pub use keycodes::chrome::{
+    code_from_key as chrome_keycode_from_key, key_from_code as chrome_key_from_code,
+};
 pub use keycodes::linux::{
     code_from_key as linux_keycode_from_key, key_from_code as linux_key_from_code,
 };
@@ -252,12 +255,11 @@ pub use keycodes::windows::{
     get_win_key, key_from_code as win_key_from_keycode, key_from_scancode as win_key_from_scancode,
     scancode_from_key as win_scancode_from_key,
 };
-pub use keycodes::chrome::{
-    code_from_key as chrome_keycode_from_key, key_from_code as chrome_key_from_code,
-};
 
 #[cfg(target_os = "macos")]
 pub use crate::keycodes::macos::{code_from_key, key_from_code, virtual_keycodes::*};
+#[cfg(target_os = "macos")]
+pub use crate::macos::exit_listen;
 #[cfg(target_os = "macos")]
 use crate::macos::{display_size as _display_size, listen as _listen, simulate as _simulate};
 #[cfg(target_os = "macos")]

--- a/src/macos/listen.rs
+++ b/src/macos/listen.rs
@@ -30,6 +30,8 @@ unsafe extern "C" fn raw_callback(
     cg_event
 }
 
+static mut CUR_LOOP: CFRunLoopSourceRef = std::ptr::null_mut();
+
 pub fn listen<T>(callback: T) -> Result<(), ListenError>
 where
     T: FnMut(Event) + 'static,
@@ -59,11 +61,21 @@ where
             return Err(ListenError::LoopSourceError);
         }
 
-        let current_loop = CFRunLoopGetMain();
-        CFRunLoopAddSource(current_loop, _loop, kCFRunLoopCommonModes);
+        CUR_LOOP = CFRunLoopGetCurrent() as _;
+        CFRunLoopAddSource(CUR_LOOP, _loop, kCFRunLoopCommonModes);
 
         CGEventTapEnable(tap, true);
         CFRunLoopRun();
+    }
+    Ok(())
+}
+
+pub fn exit_listen() -> Result<(), ListenError> {
+    unsafe {
+        if !CUR_LOOP.is_null() {
+            CFRunLoopStop(CUR_LOOP);
+            CUR_LOOP = std::ptr::null_mut();
+        }
     }
     Ok(())
 }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -9,7 +9,7 @@ pub use crate::macos::common::{map_keycode, set_is_main_thread};
 pub use crate::macos::display::display_size;
 pub use crate::macos::grab::{exit_grab, grab, is_grabbed};
 pub use crate::macos::keyboard::Keyboard;
-pub use crate::macos::listen::listen;
+pub use crate::macos::listen::{exit_listen, listen};
 pub use crate::macos::simulate::{
     set_keyboard_extra_info, set_mouse_extra_info, simulate, VirtualInput,
 };


### PR DESCRIPTION
### What does this PR do?
- Adds an `exit_listen` function similar to `exit_grab` to stop listening for events