### PR TITLE
fix(serialize): add derive macro to UnicodeInfo

### DIFF
--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -328,6 +328,7 @@ pub enum EventType {
 
 /// The Unicode information of input.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnicodeInfo {
     pub name: Option<String>,
     pub unicode: Vec<u16>,


### PR DESCRIPTION
Add #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))] to UnicodeInfo struct to enable serialization when the serialize feature is enabled.