### PR TITLE
Fix Windows JIS Muhenkan/Henkan mapping to macOS Eisu/Kana

### DIFF
--- a/src/codes_conv.rs
+++ b/src/codes_conv.rs
@@ -30,9 +30,30 @@ macro_rules! conv_keycodes {
     };
 }
 
+// JIS conversion keys occupy the same physical positions as the corresponding
+// macOS input-mode keys.
+#[allow(non_upper_case_globals)]
+fn macos_target_code_from_key(key: Key) -> Option<KeyCode> {
+    match key {
+        Key::NonConvert => Some(kVK_JIS_Eisu as _),
+        Key::Convert => Some(kVK_JIS_Kana as _),
+        _ => macos_code_from_key(key).map(|code| code as _),
+    }
+}
+
+#[cfg(target_os = "macos")]
+// Preserve the Japanese bottom-row positions when macOS is the source.
+fn windows_target_scancode_from_key(key: Key) -> Option<u32> {
+    match key {
+        Key::Lang2 => win_scancode_from_key(Key::NonConvert),
+        Key::Lang1 => win_scancode_from_key(Key::Convert),
+        _ => win_scancode_from_key(key),
+    }
+}
+
 #[allow(non_upper_case_globals)]
 fn macos_iso_code_from_key(key: Key) -> Option<KeyCode> {
-    match macos_code_from_key(key)? {
+    match macos_target_code_from_key(key)? {
         kVK_ISO_Section => Some(kVK_ANSI_Grave),
         kVK_ANSI_Grave => Some(kVK_ISO_Section),
         code => Some(code as _),
@@ -55,7 +76,7 @@ conv_keycodes!(
 conv_keycodes!(
     win_scancode_to_macos_code,
     win_key_from_scancode,
-    macos_code_from_key
+    macos_target_code_from_key
 );
 #[cfg(target_os = "windows")]
 // From Win scancode to MacOS keycode(ISO Layout)
@@ -81,7 +102,7 @@ conv_keycodes!(
 conv_keycodes!(
     linux_code_to_macos_code,
     linux_key_from_code,
-    macos_code_from_key
+    macos_target_code_from_key
 );
 #[cfg(target_os = "linux")]
 // From Linux scancode to MacOS keycode(ISO Layout)
@@ -100,7 +121,7 @@ conv_keycodes!(
 conv_keycodes!(
     macos_code_to_win_scancode,
     macos_keycode_from_code_,
-    win_scancode_from_key
+    windows_target_scancode_from_key
 );
 #[cfg(target_os = "macos")]
 conv_keycodes!(
@@ -127,7 +148,7 @@ conv_keycodes!(
 conv_keycodes!(
     usb_hid_code_to_macos_code,
     usb_hid_key_from_code,
-    macos_code_from_key
+    macos_target_code_from_key
 );
 conv_keycodes!(
     usb_hid_code_to_macos_iso_code,
@@ -142,6 +163,13 @@ conv_keycodes!(
 
 #[cfg(test)]
 mod test {
+    use crate::keycodes::macos::virtual_keycodes::{kVK_JIS_Eisu, kVK_JIS_Kana};
+
+    const USB_HID_JIS_HENKAN: u32 = 0x8A;
+    const USB_HID_JIS_MUHENKAN: u32 = 0x8B;
+    const WIN_JIS_HENKAN_SCANCODE: u32 = 0x79;
+    const WIN_JIS_MUHENKAN_SCANCODE: u32 = 0x7B;
+
     #[test]
     fn test_usb_hid_code_to_macos_code() {
         for code in 0..=65535 {
@@ -155,12 +183,24 @@ mod test {
                     continue;
                 }
                 if let Some(code2) = super::usb_hid_code_to_macos_code(usb_hid) {
-                    assert_eq!(code, code2 as u32)
+                    assert_eq!(u64::from(code), u64::from(code2))
                 } else {
                     assert!(false, "We could not convert back code: {:?}", code);
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_usb_hid_jis_keys_to_macos_code() {
+        assert_eq!(
+            super::usb_hid_code_to_macos_code(USB_HID_JIS_MUHENKAN),
+            Some(kVK_JIS_Eisu as _)
+        );
+        assert_eq!(
+            super::usb_hid_code_to_macos_code(USB_HID_JIS_HENKAN),
+            Some(kVK_JIS_Kana as _)
+        );
     }
 
     #[test]
@@ -209,19 +249,35 @@ mod test {
     // matching macOS keys when controlling a macOS peer (Map mode).
     //   無変換 (Muhenkan / NonConvert, scancode 0x7B) -> macOS 英数 (Eisu, 102)
     //   変換   (Henkan  / Convert,    scancode 0x79) -> macOS かな (Kana, 104)
-    #[cfg(target_os = "windows")]
     #[test]
     fn test_jis_muhenkan_henkan_to_macos_code() {
-        use crate::keycodes::macos::virtual_keycodes::{kVK_JIS_Eisu, kVK_JIS_Kana};
+        let muhenkan = crate::keycodes::windows::key_from_scancode(WIN_JIS_MUHENKAN_SCANCODE);
+        let henkan = crate::keycodes::windows::key_from_scancode(WIN_JIS_HENKAN_SCANCODE);
+
         assert_eq!(
-            super::win_scancode_to_macos_code(0x7B),
+            super::macos_target_code_from_key(muhenkan),
             Some(kVK_JIS_Eisu as _),
             "Muhenkan (0x7B) should map to macOS Eisu"
         );
         assert_eq!(
-            super::win_scancode_to_macos_code(0x79),
+            super::macos_target_code_from_key(henkan),
             Some(kVK_JIS_Kana as _),
             "Henkan (0x79) should map to macOS Kana"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_jis_keys_to_windows_scancode() {
+        assert_eq!(
+            super::macos_code_to_win_scancode(kVK_JIS_Eisu as _),
+            Some(WIN_JIS_MUHENKAN_SCANCODE as _),
+            "macOS Eisu should map to Windows Muhenkan"
+        );
+        assert_eq!(
+            super::macos_code_to_win_scancode(kVK_JIS_Kana as _),
+            Some(WIN_JIS_HENKAN_SCANCODE as _),
+            "macOS Kana should map to Windows Henkan"
         );
     }
 }

--- a/src/codes_conv.rs
+++ b/src/codes_conv.rs
@@ -204,4 +204,24 @@ mod test {
             }
         }
     }
+
+    // Regression test: Windows JIS Muhenkan/Henkan keys must map to the
+    // matching macOS keys when controlling a macOS peer (Map mode).
+    //   無変換 (Muhenkan / NonConvert, scancode 0x7B) -> macOS 英数 (Eisu, 102)
+    //   変換   (Henkan  / Convert,    scancode 0x79) -> macOS かな (Kana, 104)
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_jis_muhenkan_henkan_to_macos_code() {
+        use crate::keycodes::macos::virtual_keycodes::{kVK_JIS_Eisu, kVK_JIS_Kana};
+        assert_eq!(
+            super::win_scancode_to_macos_code(0x7B),
+            Some(kVK_JIS_Eisu as _),
+            "Muhenkan (0x7B) should map to macOS Eisu"
+        );
+        assert_eq!(
+            super::win_scancode_to_macos_code(0x79),
+            Some(kVK_JIS_Kana as _),
+            "Henkan (0x79) should map to macOS Kana"
+        );
+    }
 }

--- a/src/codes_conv.rs
+++ b/src/codes_conv.rs
@@ -162,7 +162,9 @@ mod test {
 
     const USB_HID_JIS_HENKAN: u32 = 0x8A;
     const USB_HID_JIS_MUHENKAN: u32 = 0x8B;
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     const WIN_JIS_HENKAN_SCANCODE: u32 = 0x79;
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     const WIN_JIS_MUHENKAN_SCANCODE: u32 = 0x7B;
     #[cfg(target_os = "macos")]
     const LINUX_X11_JIS_HENKAN_KEYCODE: u32 = 0x64;
@@ -248,18 +250,16 @@ mod test {
     // matching macOS keys when controlling a macOS peer (Map mode).
     //   無変換 (Muhenkan / NonConvert, scancode 0x7B) -> macOS 英数 (Eisu, 102)
     //   変換   (Henkan  / Convert,    scancode 0x79) -> macOS かな (Kana, 104)
+    #[cfg(target_os = "windows")]
     #[test]
     fn test_jis_muhenkan_henkan_to_macos_code() {
-        let muhenkan = crate::keycodes::windows::key_from_scancode(WIN_JIS_MUHENKAN_SCANCODE);
-        let henkan = crate::keycodes::windows::key_from_scancode(WIN_JIS_HENKAN_SCANCODE);
-
         assert_eq!(
-            super::macos_target_code_from_key(muhenkan),
+            super::win_scancode_to_macos_code(WIN_JIS_MUHENKAN_SCANCODE),
             Some(kVK_JIS_Eisu as _),
             "Muhenkan (0x7B) should map to macOS Eisu"
         );
         assert_eq!(
-            super::macos_target_code_from_key(henkan),
+            super::win_scancode_to_macos_code(WIN_JIS_HENKAN_SCANCODE),
             Some(kVK_JIS_Kana as _),
             "Henkan (0x79) should map to macOS Kana"
         );

--- a/src/codes_conv.rs
+++ b/src/codes_conv.rs
@@ -41,16 +41,6 @@ fn macos_target_code_from_key(key: Key) -> Option<KeyCode> {
     }
 }
 
-#[cfg(target_os = "macos")]
-// Preserve the Japanese bottom-row positions when macOS is the source.
-fn windows_target_scancode_from_key(key: Key) -> Option<u32> {
-    match key {
-        Key::Lang2 => win_scancode_from_key(Key::NonConvert),
-        Key::Lang1 => win_scancode_from_key(Key::Convert),
-        _ => win_scancode_from_key(key),
-    }
-}
-
 #[allow(non_upper_case_globals)]
 fn macos_iso_code_from_key(key: Key) -> Option<KeyCode> {
     match macos_target_code_from_key(key)? {
@@ -63,7 +53,12 @@ fn macos_iso_code_from_key(key: Key) -> Option<KeyCode> {
 #[cfg(target_os = "macos")]
 #[allow(non_upper_case_globals)]
 fn macos_keycode_from_code_(code: KeyCode) -> Key {
-    macos_key_from_code(map_keycode(code))
+    // Preserve the Japanese bottom-row positions when macOS is the source.
+    match macos_key_from_code(map_keycode(code)) {
+        Key::Lang2 => Key::NonConvert,
+        Key::Lang1 => Key::Convert,
+        key => key,
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -121,7 +116,7 @@ conv_keycodes!(
 conv_keycodes!(
     macos_code_to_win_scancode,
     macos_keycode_from_code_,
-    windows_target_scancode_from_key
+    win_scancode_from_key
 );
 #[cfg(target_os = "macos")]
 conv_keycodes!(
@@ -169,6 +164,10 @@ mod test {
     const USB_HID_JIS_MUHENKAN: u32 = 0x8B;
     const WIN_JIS_HENKAN_SCANCODE: u32 = 0x79;
     const WIN_JIS_MUHENKAN_SCANCODE: u32 = 0x7B;
+    #[cfg(target_os = "macos")]
+    const LINUX_X11_JIS_HENKAN_KEYCODE: u32 = 0x64;
+    #[cfg(target_os = "macos")]
+    const LINUX_X11_JIS_MUHENKAN_KEYCODE: u32 = 0x66;
 
     #[test]
     fn test_usb_hid_code_to_macos_code() {
@@ -278,6 +277,21 @@ mod test {
             super::macos_code_to_win_scancode(kVK_JIS_Kana as _),
             Some(WIN_JIS_HENKAN_SCANCODE as _),
             "macOS Kana should map to Windows Henkan"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_jis_keys_to_linux_keycode() {
+        assert_eq!(
+            super::macos_code_to_linux_code(kVK_JIS_Eisu as _),
+            Some(LINUX_X11_JIS_MUHENKAN_KEYCODE as _),
+            "macOS Eisu should map to Linux Muhenkan"
+        );
+        assert_eq!(
+            super::macos_code_to_linux_code(kVK_JIS_Kana as _),
+            Some(LINUX_X11_JIS_HENKAN_KEYCODE as _),
+            "macOS Kana should map to Linux Henkan"
         );
     }
 }

--- a/src/keycodes/chrome.rs
+++ b/src/keycodes/chrome.rs
@@ -150,8 +150,10 @@ decl_keycodes! {
     VolumeUp, "AudioVolumeUp", // "AudioVolumeUp" (was "VolumeUp" prior to Chrome 52) (⚠️ Not the same on Firefox)
     VolumeDown, "AudioVolumeDown", // "AudioVolumeDown" (was "VolumeDown" prior to Chrome 52) (⚠️ Not the same on Firefox)
     VolumeMute, "AudioVolumeMute", // "AudioVolumeMute" (was "VolumeMute" prior to Chrome 52) (⚠️ Not the same on Firefox)
-    Lang1, "NonConvert", // "NonConvert" (was "" prior to Chrome 48)
-    Lang2, "Convert", // "Convert" (was "" prior to Chrome 48)
+    NonConvert, "NonConvert", // "NonConvert" (was "" prior to Chrome 48)
+    Convert, "Convert", // "Convert" (was "" prior to Chrome 48)
+    Lang1, "Lang1",
+    Lang2, "Lang2",
     Lang3, "Lang3", // "Lang3" (was "" prior to Chrome 48)
     Lang4, "Lang4", // "Lang4" (was "" prior to Chrome 48)
     Lang5, "Lang5", // "Lang5" (was "" prior to Chrome 48) (⚠️ Not the same on Firefox) Lang5 in https://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/translate.pdf is 0x0075, while is "Lang5" in https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code is 0x005D

--- a/src/keycodes/linux.rs
+++ b/src/keycodes/linux.rs
@@ -16,6 +16,7 @@ macro_rules! decl_keycodes {
         //TODO: make const when rust lang issue #49146 is fixed
         #[allow(dead_code)]
         pub fn key_from_code(code: u32) -> Key {
+            #[allow(unreachable_patterns)]
             match code {
                 $(
                     $code => Key::$key,
@@ -153,11 +154,19 @@ decl_keycodes!(
     VolumeUp, 0x007B,
     VolumeDown, 0x007A,
     VolumeMute, 0x0079,
-    Lang1, 0x0066,
-    Lang2, 0x0064,
+    NonConvert, 0x0066,
+    Convert, 0x0064,
     Lang3, 0x0062,
     Lang4, 0x0063,
-    Lang5, 0x005d
+    Lang5, 0x005d,
+    // Linux KEY_HANGEUL (122) and KEY_HANJA (123), plus the X11 offset of 8:
+    // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/input-event-codes.h
+    // https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/keycodes/evdev
+    // Keep native keys first for X11 decoding; LANG keys are encoding aliases.
+    Hangul, 0x0082,
+    Lang1, 0x0082,
+    Hanja, 0x0083,
+    Lang2, 0x0083
 );
 
 #[cfg(test)]

--- a/src/keycodes/macos.rs
+++ b/src/keycodes/macos.rs
@@ -130,9 +130,17 @@ decl_keycodes!(
     F3, kVK_F3,
     F8, kVK_F8,
     F9, kVK_F9,
-    Lang2, kVK_JIS_Eisu,
+    // NOTE: In this crate `Key::Lang1`/`Key::Lang2` are NOT the standard HID
+    // LANG1/LANG2 (0x90/0x91, i.e. Windows ImeOn/ImeOff). The source tables
+    // (windows/linux/usb_hid) bind them to the JIS Muhenkan/Henkan keys:
+    //   Key::Lang1 = 無変換 (Muhenkan / VK_NONCONVERT 0x1D / HID Intl5 0x8B)
+    //   Key::Lang2 = 変換   (Henkan   / VK_CONVERT    0x1C / HID Intl4 0x8A)
+    // So when controlling a macOS peer we map them by physical/functional
+    // position (left-of-space = alphanumeric, right-of-space = kana):
+    //   無変換 (Lang1) -> 英数 (Eisu),  変換 (Lang2) -> かな (Kana)
+    Lang2, kVK_JIS_Kana,
     F11, kVK_F11,
-    Lang1, kVK_JIS_Kana,
+    Lang1, kVK_JIS_Eisu,
     // PrintScreen, kVK_F13,
     F13, kVK_F13,
     F16, kVK_F16,

--- a/src/keycodes/macos.rs
+++ b/src/keycodes/macos.rs
@@ -130,17 +130,9 @@ decl_keycodes!(
     F3, kVK_F3,
     F8, kVK_F8,
     F9, kVK_F9,
-    // NOTE: In this crate `Key::Lang1`/`Key::Lang2` are NOT the standard HID
-    // LANG1/LANG2 (0x90/0x91, i.e. Windows ImeOn/ImeOff). The source tables
-    // (windows/linux/usb_hid) bind them to the JIS Muhenkan/Henkan keys:
-    //   Key::Lang1 = 無変換 (Muhenkan / VK_NONCONVERT 0x1D / HID Intl5 0x8B)
-    //   Key::Lang2 = 変換   (Henkan   / VK_CONVERT    0x1C / HID Intl4 0x8A)
-    // So when controlling a macOS peer we map them by physical/functional
-    // position (left-of-space = alphanumeric, right-of-space = kana):
-    //   無変換 (Lang1) -> 英数 (Eisu),  変換 (Lang2) -> かな (Kana)
-    Lang2, kVK_JIS_Kana,
+    Lang2, kVK_JIS_Eisu,
     F11, kVK_F11,
-    Lang1, kVK_JIS_Eisu,
+    Lang1, kVK_JIS_Kana,
     // PrintScreen, kVK_F13,
     F13, kVK_F13,
     F16, kVK_F16,

--- a/src/keycodes/usb_hid.rs
+++ b/src/keycodes/usb_hid.rs
@@ -157,8 +157,15 @@ decl_keycodes! {
     VolumeUp, 0x80,
     VolumeDown, 0x81,
     VolumeMute, 0x7F,
-    Lang1, 0x8B,
-    Lang2, 0x8A,
+    Convert, 0x8A,
+    NonConvert, 0x8B,
+    // USB HID Usage Tables, Keyboard/Keypad Page (0x07):
+    // https://www.usb.org/sites/default/files/hut1_7.pdf
+    // Keep LANG keys first for HID decoding; Hangul/Hanja are encoding aliases.
+    Lang1, 0x90,
+    Hangul, 0x90,
+    Lang2, 0x91,
+    Hanja, 0x91,
     Lang3, 0x92,
     Lang4, 0x93,
     Lang5, 0x94,
@@ -167,7 +174,6 @@ decl_keycodes! {
     Kana, 0x88,
     Junja, 0x00,
     Final, 0x00,
-    Hanja, 0x91,
     Select, 0x77,
     Print, 0x00,
     Execute, 0x74,

--- a/src/keycodes/windows.rs
+++ b/src/keycodes/windows.rs
@@ -206,17 +206,24 @@ decl_keycodes! {
     VolumeUp, 0x00AF, 0xE030,
     VolumeDown, 0x00AE, 0xE02E,
     VolumeMute, 0x00AD, 0xE020,
-    Lang1, 0x1D, 0x007b,
-    Lang2, 0x1C, 0x0079,
+    NonConvert, 0x1D, 0x007b,
+    Convert, 0x1C, 0x0079,
     Lang3, 0x0000, 0x0078,
     Lang4, 0x0000, 0x0077,
     Lang5, 0x0000, 0x0076,
     Cancel, 0x03, 0x0000,
     Clear, 12, 0x0000,
     Kana, 0x15, 0x0080,
+    // Windows virtual-key names and USB HID-to-scan-code mappings:
+    // https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+    // https://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/translate.pdf
+    // Keep native keys first for scan-code decoding; LANG keys are encoding aliases.
+    Hangul, 0x15, 0x00f2,
+    Lang1, 0x15, 0x00f2,
     Junja, 0x17, 0x0000,
     Final, 0x18, 0x0000,
     Hanja, 0x19, 0x00f1,
+    Lang2, 0x19, 0x00f1,
     Select, 0x29, 0x0000,
     Print, 0x2A, 0x0000,
     Execute, 0x2B, 0x0000,

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -205,7 +205,7 @@ pub enum Key {
     BackSlash,
     IntlBackslash,
     IntlRo,   // Brazilian /? and Japanese _ 'ro'
-    IntlYen,  // Japanese Henkan (Convert) key.
+    IntlYen,  // Japanese yen key.
     KanaMode, // Japanese Hiragana/Katakana key.
     KeyZ,
     KeyX,
@@ -262,6 +262,11 @@ pub enum Key {
     Separator,
     Unknown(u32),
     RawKey(RawKey),
+    // Keep new variants last to preserve existing serialized discriminants.
+    /// Japanese Henkan (Convert) key.
+    Convert,
+    /// Japanese Muhenkan (NonConvert) key.
+    NonConvert,
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
### Problem
When a Windows client with a JIS keyboard controls a macOS peer (Map mode),
Muhenkan (無変換) is delivered to macOS as Kana (かな) and Henkan (変換) as
Eisu (英数) — the reverse of what users expect.

### Cause
The chain is: win scancode → `Key` → macOS keycode. All source tables
(windows/linux/usb_hid) bind `Key::Lang1` = Muhenkan and `Key::Lang2` = Henkan
(HID Intl5 0x8B / Intl4 0x8A, VK_NONCONVERT / VK_CONVERT — NOT the standard HID
LANG1/LANG2 0x90/0x91). Only `keycodes/macos.rs` was inconsistent, mapping
Lang1→Kana and Lang2→Eisu.

### Fix
Map by physical/functional position (left-of-space = alphanumeric,
right-of-space = kana):
- `Key::Lang1` (Muhenkan) → `kVK_JIS_Eisu`
- `Key::Lang2` (Henkan)   → `kVK_JIS_Kana`

Adds a regression test (win scancode 0x7B → Eisu, 0x79 → Kana).
Verified end-to-end on a real Windows→macOS session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated support for Japanese **Convert** and **NonConvert** keys across platforms, including Chrome `KeyboardEvent.code` mapping.
* **Bug Fixes**
  * Improved Japanese IME key conversions (Muhenkan/Henkan ↔ Eisu/Kana) with correct macOS key target remapping while preserving Japanese bottom-row physical positions.
  * Updated **Lang1/Lang2**, **Hangul/Hanja**, and related encoding key mappings on Linux, Windows, and USB HID.
* **Tests**
  * Expanded regression coverage for USB HID and Windows JIS conversions, plus macOS-only inverse mapping checks (macOS↔Windows and macOS↔Linux).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->